### PR TITLE
Change the method identifier "toSAX" to "addSAX".

### DIFF
--- a/fop-core/src/main/java/org/apache/fop/render/afp/extensions/AFPIncludeFormMap.java
+++ b/fop-core/src/main/java/org/apache/fop/render/afp/extensions/AFPIncludeFormMap.java
@@ -65,6 +65,20 @@ public class AFPIncludeFormMap extends AFPExtensionAttachment {
     }
 
     /** {@inheritDoc} */
+    public void addSAX(ContentHandler handler) throws SAXException {
+        AttributesImpl atts = new AttributesImpl();
+        if (name != null && name.length() > 0) {
+            atts.addAttribute("", ATT_NAME, ATT_NAME, "CDATA", name);
+        }
+        if (this.src != null) {
+            atts.addAttribute("", ATT_SRC, ATT_SRC, "CDATA", this.src.toASCIIString());
+        }
+        handler.startElement(CATEGORY, elementName, elementName, atts);
+        handler.endElement(CATEGORY, elementName, elementName);
+    }
+    
+    /** {@inheritDoc} */
+    @Deprecated
     public void toSAX(ContentHandler handler) throws SAXException {
         AttributesImpl atts = new AttributesImpl();
         if (name != null && name.length() > 0) {


### PR DESCRIPTION
The method body code seems to add a new attribute to the parameter "handler".
Identifier "addSAX" should be better than "toSAX" since 'toSAX' is prone to convert one thing to another.