### PR TITLE
FOP-2788: Change the two method names.

### DIFF
--- a/fop-core/src/main/java/org/apache/fop/afp/AFPResourceManager.java
+++ b/fop-core/src/main/java/org/apache/fop/afp/AFPResourceManager.java
@@ -124,7 +124,7 @@ public class AFPResourceManager {
      *
      * @throws IOException thrown if an I/O exception of some sort has occurred.
      */
-    public void writeToStream() throws IOException {
+    public void closeStream() throws IOException {
         streamer.close();
     }
 

--- a/fop-core/src/main/java/org/apache/fop/render/afp/AFPDocumentHandler.java
+++ b/fop-core/src/main/java/org/apache/fop/render/afp/AFPDocumentHandler.java
@@ -204,7 +204,7 @@ public class AFPDocumentHandler extends AbstractBinaryWritingIFDocumentHandler
         try {
             this.dataStream.endDocument();
             this.dataStream = null;
-            this.resourceManager.writeToStream();
+            this.resourceManager.closeStream();
             this.resourceManager = null;
         } catch (IOException ioe) {
             throw new IFException("I/O error in endDocument()", ioe);

--- a/fop-events/src/main/java/org/apache/fop/events/Event.java
+++ b/fop-events/src/main/java/org/apache/fop/events/Event.java
@@ -182,7 +182,7 @@ public class Event extends EventObject {
          * Returns the accumulated parameter map.
          * @return the accumulated parameter map
          */
-        public Map<String, Object> build() {
+        public Map<String, Object> getParams() {
             return this.params;
         }
     }

--- a/fop-events/src/test/java/org/apache/fop/events/BasicEventTestCase.java
+++ b/fop-events/src/test/java/org/apache/fop/events/BasicEventTestCase.java
@@ -44,7 +44,7 @@ public class BasicEventTestCase {
                 Event.paramsBuilder()
                     .param("reason", "I'm tired")
                     .param("blah", Integer.valueOf(23))
-                    .build());
+                    .getParams());
         broadcaster.broadcastEvent(ev);
 
         ev = listener.event;


### PR DESCRIPTION
The first method closes a stream, but its name is "writetoStream". The method name "closeStream" should be better.
The second method just returns one field "params" of the current class, thus method name "getParams" should be better than "build".