### PR TITLE
FOP-2704: Make Google Roboto font (and probably others) usable

### DIFF
--- a/fop-core/src/main/java/org/apache/fop/complexscripts/fonts/OTFAdvancedTypographicTableReader.java
+++ b/fop-core/src/main/java/org/apache/fop/complexscripts/fonts/OTFAdvancedTypographicTableReader.java
@@ -3336,7 +3336,12 @@ public final class OTFAdvancedTypographicTableReader {
             msca[i] = readCoverageTable(tableTag + " mark set coverage[" + i + "]", subtableOffset + mso[i]);
         }
         // create combined class table from per-class coverage tables
-        GlyphClassTable ct = GlyphClassTable.createClassTable(Arrays.asList(msca));
+        GlyphClassTable ct = null;
+        try {
+            ct = GlyphClassTable.createClassTable(Arrays.asList(msca));
+        } catch (UnsupportedOperationException uoe) {
+            log.debug(uoe.getMessage(), uoe);
+        }
         // store results
         seMapping = ct;
         // extract subtable
@@ -3580,14 +3585,16 @@ public final class OTFAdvancedTypographicTableReader {
     }
 
     private void constructLookupsLanguage(Map lookups, String st, String lt, Map<String, Object> languages) {
+        if (languages != null) {
         Object[] lp = (Object[]) languages.get(lt);
-        if (lp != null) {
-            assert lp.length == 2;
-            if (lp[0] != null) {                      // required feature id
-                constructLookupsFeature(lookups, st, lt, (String) lp[0]);
-            }
-            if (lp[1] != null) {                      // non-required features ids
-                constructLookupsFeatures(lookups, st, lt, (List) lp[1]);
+            if (lp != null) {
+                assert lp.length == 2;
+                if (lp[0] != null) {                      // required feature id
+                    constructLookupsFeature(lookups, st, lt, (String) lp[0]);
+                }
+                if (lp[1] != null) {                      // non-required features ids
+                    constructLookupsFeatures(lookups, st, lt, (List) lp[1]);
+                }
             }
         }
     }

--- a/fop-core/src/main/java/org/apache/fop/complexscripts/fonts/OTFAdvancedTypographicTableReader.java
+++ b/fop-core/src/main/java/org/apache/fop/complexscripts/fonts/OTFAdvancedTypographicTableReader.java
@@ -3586,7 +3586,7 @@ public final class OTFAdvancedTypographicTableReader {
 
     private void constructLookupsLanguage(Map lookups, String st, String lt, Map<String, Object> languages) {
         if (languages != null) {
-        Object[] lp = (Object[]) languages.get(lt);
+            Object[] lp = (Object[]) languages.get(lt);
             if (lp != null) {
                 assert lp.length == 2;
                 if (lp[0] != null) {                      // required feature id


### PR DESCRIPTION
This is a re-post of #59 which was apparently closed by an automatic process and/or due to a force-push on the `fop-2_3` branch?

It applies the patch brought forward by Neil Smeby in https://issues.apache.org/jira/browse/FOP-2704. In short, it works around the UnsupportedOperationException: coverage set class table not yet supported exception when trying to use Google's Roboto font (updated 2017).

See https://jitpack.io/#webfactory/fop/48e0a1567 how you can easily give this patch a try with your preferred build system.