### PR TITLE
FOP-2858 java.awt.Font.getName() returns localized name

### DIFF
--- a/fop-core/src/main/java/org/apache/fop/render/java2d/InstalledFontCollection.java
+++ b/fop-core/src/main/java/org/apache/fop/render/java2d/InstalledFontCollection.java
@@ -91,7 +91,7 @@ public class InstalledFontCollection implements FontCollection {
                         + ", Style: " + f.getStyle());
             }
 
-            String searchName = FontUtil.stripWhiteSpace(f.getName()).toLowerCase();
+            String searchName = FontUtil.stripWhiteSpace(f.getFontName(Locale.ENGLISH)).toLowerCase();
             String guessedStyle = FontUtil.guessStyle(searchName);
             int guessedWeight = FontUtil.guessWeight(searchName);
 


### PR DESCRIPTION
As described here https://issues.apache.org/jira/browse/FOP-2858?filter=-2, this patch fixes the font name localization problem, which prevents guessWeight/Style methods from working as they are based on english keywords.