### PR TITLE
FOP-2854: Allow to override CreationDate

### DIFF
--- a/fop-core/src/main/java/org/apache/fop/pdf/PDFMetadata.java
+++ b/fop-core/src/main/java/org/apache/fop/pdf/PDFMetadata.java
@@ -134,7 +134,9 @@ public class PDFMetadata extends PDFStream {
 
         //Set creation date if not available, yet
         if (info.getCreationDate() == null) {
-            Date d = new Date();
+            Date d = System.getenv("SOURCE_DATE_EPOCH") == null ?
+                new Date() :
+                new Date(1000 * Long.parseLong(System.getenv("SOURCE_DATE_EPOCH")));
             info.setCreationDate(d);
         }
 


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This patch was done while working on reproducible builds for openSUSE.