### PR TITLE
Include xmlapis*.jar when creating fop.war

### DIFF
--- a/fop/build.xml
+++ b/fop/build.xml
@@ -600,6 +600,7 @@ list of possible build targets.
         <include name="batik*.jar"/>
         <include name="commons-io*.jar"/>
         <include name="xmlgraphics*.jar"/>
+        <include name="xml-apis*jar" />
       </lib>
       <lib dir="${build.dir}">
         <include name="fop.jar"/>


### PR DESCRIPTION
This prevents
```
<4>Batik not in class path
<4>java.lang.NoClassDefFoundError: org/w3c/dom/svg/SVGDocument
<4>    at java.base/java.lang.ClassLoader.defineClass1(Native Method)
<4>    at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017)
<4>    at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174)
```