### PR TITLE
FOP-3226. Use central repo, not repository.apache.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,14 @@
 
   <repositories>
     <repository>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
       <id>apache.snapshots.https</id>
       <url>https://repository.apache.org/content/repositories/snapshots</url>
       <releases>
@@ -163,16 +171,6 @@
       </releases>
       <snapshots>
         <enabled>true</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>apache.releases.https</id>
-      <url>https://repository.apache.org/content/repositories/releases</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
       </snapshots>
     </repository>
     <repository>


### PR DESCRIPTION
## What changes were proposed in this pull request?

[Build](https://github.com/apache/xmlgraphics-fop/actions/runs/12164170681/job/33925162614#step:4:1413) tries to download non-Apache artifacts from `repository.apache.org`:

```
[INFO] Downloading from apache.releases.https: https://repository.apache.org/content/repositories/releases/org/junit/junit-bom/5.11.0/junit-bom-5.11.0.pom
[INFO] Downloading from jboss.org: https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/org/junit/junit-bom/5.11.0/junit-bom-5.11.0.pom
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.11.0/junit-bom-5.11.0.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.11.0/junit-bom-5.11.0.pom (5.6 kB at 706 kB/s)
```

- Remove `repository.apache.org` for releases.
- Add `central` repo definition.  This is inherited, too, but repos in `pom.xml` have higher precedence.  So this is needed only to avoid hitting jboss.org unnecessarily.

https://issues.apache.org/jira/browse/FOP-3226

## How was this patch tested?

```
$ mvn -DskipTests clean package
...
[INFO] Reactor Summary for Apache FOP Parent 2.10.0-SNAPSHOT:
[INFO] 
[INFO] Apache FOP Parent .................................. SUCCESS [  0.123 s]
[INFO] Apache FOP Utilities ............................... SUCCESS [  1.792 s]
[INFO] Apache FOP Events .................................. SUCCESS [  0.425 s]
[INFO] Apache FOP Core .................................... SUCCESS [ 17.353 s]
[INFO] Apache FOP All-In-One .............................. SUCCESS [  0.022 s]
[INFO] Apache FOP Sandbox ................................. SUCCESS [  0.117 s]
[INFO] Apache FOP Servlet ................................. SUCCESS [  1.658 s]
[INFO] Apache FOP Transcoder .............................. SUCCESS [  0.393 s]
[INFO] Apache FOP Transcoder All-In-One ................... SUCCESS [  0.221 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```