### PR TITLE
Make embedded timestamps reproducible and use SOURCE_DATE_EPOCH if available

### DIFF
--- a/fop-core/src/main/java/org/apache/fop/cli/CommandLineOptions.java
+++ b/fop-core/src/main/java/org/apache/fop/cli/CommandLineOptions.java
@@ -25,6 +25,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URI;
+import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Vector;
@@ -234,6 +235,12 @@ public class CommandLineOptions {
             //Make sure the prepared serializer is used
             foUserAgent.setDocumentHandlerOverride(serializer);
         }
+
+	String sourceDateEpoch = System.getenv("SOURCE_DATE_EPOCH");
+	if (sourceDateEpoch != null) {
+		foUserAgent.setCreationDate(new Date(1000 * Long.parseLong(sourceDateEpoch)));
+	}
+
         return true;
     }
 

--- a/fop-core/src/main/java/org/apache/fop/pdf/FileIDGenerator.java
+++ b/fop-core/src/main/java/org/apache/fop/pdf/FileIDGenerator.java
@@ -86,7 +86,11 @@ abstract class FileIDGenerator {
 
         private void generateFileID() {
             DateFormat df = new SimpleDateFormat("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'SSS");
-            digest.update(PDFDocument.encode(df.format(new Date())));
+            Date date = this.document.getInfo().getCreationDate();
+            if (date == null) {
+                    date = new Date();
+            }
+            digest.update(PDFDocument.encode(df.format(date)));
             // Ignoring the filename here for simplicity even though it's recommended
             // by the PDF spec
             digest.update(PDFDocument.encode(String.valueOf(document.getCurrentFileSize())));

--- a/fop-core/src/main/java/org/apache/fop/render/pdf/PDFRenderingUtil.java
+++ b/fop-core/src/main/java/org/apache/fop/render/pdf/PDFRenderingUtil.java
@@ -262,7 +262,11 @@ class PDFRenderingUtil {
         fopXMP.mergeInto(docXMP, exclude);
         XMPBasicAdapter xmpBasic = XMPBasicSchema.getAdapter(docXMP);
         //Metadata was changed so update metadata date
-        xmpBasic.setMetadataDate(new java.util.Date());
+        Date date = userAgent.getCreationDate();
+        if (date == null) {
+                date = new Date();
+        }
+        xmpBasic.setMetadataDate(date);
         PDFMetadata.updateInfoFromMetadata(docXMP, pdfDoc.getInfo());
 
         PDFMetadata pdfMetadata = pdfDoc.getFactory().makeMetadata(


### PR DESCRIPTION
SOURCE_DATE_EPOCH is a standardized environment variable used during
reproducible builds to fix timestamps in files with a known value.

Link: https://reproducible-builds.org/specs/source-date-epoch/